### PR TITLE
feat: added externalid column in loan product

### DIFF
--- a/src/app/products/loan-products/loan-products.component.html
+++ b/src/app/products/loan-products/loan-products.component.html
@@ -26,6 +26,11 @@
         <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.Short Name' | translate }}</th>
         <td mat-cell *matCellDef="let loanProduct">{{ loanProduct.shortName }}</td>
       </ng-container>
+            
+      <ng-container matColumnDef="externalId">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.External ID' | translate }}</th>
+        <td mat-cell *matCellDef="let loanProduct">{{ loanProduct.externalId }}</td>
+      </ng-container>
 
       <ng-container matColumnDef="closeDate">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.Expiry Date' | translate }}</th>

--- a/src/app/products/loan-products/loan-products.component.ts
+++ b/src/app/products/loan-products/loan-products.component.ts
@@ -19,6 +19,7 @@ export class LoanProductsComponent implements OnInit, AfterViewInit {
   displayedColumns: string[] = [
     'name',
     'shortName',
+    'externalId',
     'closeDate',
     'status'
   ];

--- a/src/app/products/loan-products/models/loan-product.model.ts
+++ b/src/app/products/loan-products/models/loan-product.model.ts
@@ -15,6 +15,7 @@ export interface LoanProduct {
   id: number;
   name: string;
   shortName: string;
+  externalId?: string;
   includeInBorrowerCycle: boolean;
   useBorrowerCycle: boolean;
   status: string;


### PR DESCRIPTION
## Description

External ID can be used to link product type in CredibleX system to Fineract. 
Added a column in loan product listing to show "External ID" in the table

## Related issues and discussion

#{Issue Number}

## Screenshots, if any
![image](https://github.com/user-attachments/assets/acfd21bd-e1b9-46b1-bd2f-4273ab7200a6)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
