### PR TITLE
feat(CRED-74): Loan summary view  - Disburse Net Loan Amount After Deducting Fees

### DIFF
--- a/src/app/loans/loans-view/general-tab/general-tab.component.html
+++ b/src/app/loans/loans-view/general-tab/general-tab.component.html
@@ -24,7 +24,7 @@
   </ng-container>
 
   <div *ngIf="loanDetails.summary">
-    <h3>{{ 'labels.heading.Loan Summary' | translate }}</h3>
+    <h3>{{ 'labels.heading.Loan Summaryx' | translate }}</h3>
 
     <table mat-table [dataSource]="dataSource">
       <ng-container matColumnDef="Empty">
@@ -135,6 +135,12 @@
             *ngIf="ele.key === 'Proposed Amount' || ele.key === 'Approved Amount' || ele.key === 'Disburse Amount'"
           >
             {{ ele.value }}
+          </ng-container>
+
+          <ng-container *ngIf="ele.key === 'Net Disbursed Amount'">
+            <span>
+              {{ ele.value }}
+            </span>
           </ng-container>
         </td>
       </ng-container>

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1522,6 +1522,7 @@
       "Disbursement on": "Výplata zapnuta",
       "Display Name": "Zobrazovaný název",
       "Dividend Amount": "Částka dividendy",
+      "Net Dividend Amount": "Čistá částka dividendy",
       "Dividend Period End Date": "Datum ukončení dividendového období",
       "Dividend Period Start Date": "Datum zahájení dividendového období",
       "Dividends": "Dividendy",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1513,6 +1513,7 @@
       "Disabled": "Deaktiviert",
       "Disallow Expected Disbursements": "Erwartete Auszahlungen nicht zulassen",
       "Disburse Amount": "Auszahlungsbetrag",
+      "Net Disbursed Amount": "Nettobetrag ausgezahlt",
       "Disbursed Amount Percentage Down Payment": "Prozentsatz der ausgezahlten Anzahlung",
       "Disbursed On": "Ausgezahlt am",
       "Disbursed On Date": "Auszahlungsdatum",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1524,6 +1524,7 @@
       "Disabled": "Disabled",
       "Disallow Expected Disbursements": "Disallow Expected Disbursements",
       "Disburse Amount": "Disburse Amount",
+      "Net Disbursed Amount": "Net Disbursed Amount",
       "Disbursed Amount Percentage Down Payment": "Disbursed Amount Percentage Down Payment",
       "Disbursed On": "Disbursed On",
       "Disbursed On Date": "Disbursed On Date",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -1512,6 +1512,7 @@
       "Disabled": "Desactivado",
       "Disallow Expected Disbursements": "No requiere información de desembolsos esperados",
       "Disburse Amount": "Monto Cursado",
+      "Net Disburse Amount": "Importe neto desembolsado",
       "Disbursed Amount Percentage Down Payment": "Porcentaje del monto cursado para el Pago inicial",
       "Disbursed On": "Cursado el",
       "Disbursed On Date": "Cursado en la fecha",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -1512,6 +1512,7 @@
       "Disabled": "Desactivado",
       "Disallow Expected Disbursements": "No requiere información de desembolsos esperados",
       "Disburse Amount": "Monto Desembolsado",
+      "Net Disbursed Amount": "Monto neto desembolsado",
       "Disbursed Amount Percentage Down Payment": "Porcentaje del monto desembolsado para el Pago inicial",
       "Disbursed On": "Desembolsado el",
       "Disbursed On Date": "Desembolsado en la fecha",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1513,6 +1513,7 @@
       "Disabled": "Désactivé",
       "Disallow Expected Disbursements": "Refuser les décaissements prévus",
       "Disburse Amount": "Montant du décaissement",
+      "Net Disbursed Amount": "Montant net décaissé",
       "Disbursed Amount Percentage Down Payment": "Montant décaissé Pourcentage Acompte",
       "Disbursed On": "Décaissé le",
       "Disbursed On Date": "Date de décaissement",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1513,6 +1513,7 @@
       "Disabled": "Disabilitato",
       "Disallow Expected Disbursements": "Non consentire gli esborsi previsti",
       "Disburse Amount": "Importo da erogare",
+      "Net Disbursed Amount": "Importo netto erogato",
       "Disbursed Amount Percentage Down Payment": "Acconto percentuale importo erogato",
       "Disbursed On": "Erogato il",
       "Disbursed On Date": "Erogato in data",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -1514,6 +1514,7 @@
       "Disabled": "장애가 있는",
       "Disallow Expected Disbursements": "예상되는 지불을 허용하지 않음",
       "Disburse Amount": "지급금액",
+      "Net Disbursed Amount": "순지급금액",
       "Disbursed Amount Percentage Down Payment": "지불 금액 비율 계약금",
       "Disbursed On": "지급 날짜",
       "Disbursed On Date": "지급 날짜",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1513,6 +1513,7 @@
       "Disabled": "Išjungta",
       "Disallow Expected Disbursements": "Neleisti numatomų išmokėjimų",
       "Disburse Amount": "Išmokos suma",
+      "Net Disbursed Amount": "Išmokėta suma",
       "Disbursed Amount Percentage Down Payment": "Išmokėtos sumos procentinė įmoka",
       "Disbursed On": "Išmokėta",
       "Disbursed On Date": "Išmokėta datą",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1513,6 +1513,7 @@
       "Disabled": "Atspējots",
       "Disallow Expected Disbursements": "Neatļaut sagaidāmās izmaksas",
       "Disburse Amount": "Izmaksas summa",
+      "Net Disbursed Amount": "Neto izmaksātā summa",
       "Disbursed Amount Percentage Down Payment": "Izmaksātās summas procentuālā pirmā iemaksa",
       "Disbursed On": "Izmaksāts",
       "Disbursed On Date": "Izmaksāts datumā",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1513,6 +1513,7 @@
       "Disabled": "अक्षम",
       "Disallow Expected Disbursements": "अपेक्षित वितरण अस्वीकार गर्नुहोस्",
       "Disburse Amount": "निकासा रकम",
+      "Net Disbursed Amount": "नेट वितरण गरिएको रकम",
       "Disbursed Amount Percentage Down Payment": "वितरण गरिएको रकम प्रतिशत तल भुक्तानी",
       "Disbursed On": "मा वितरण गरियो",
       "Disbursed On Date": "मितिमा वितरण गरियो",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1513,6 +1513,7 @@
       "Disabled": "Desabilitado",
       "Disallow Expected Disbursements": "Proibir desembolsos esperados",
       "Disburse Amount": "Valor do Desembolso",
+      "Net Disbursed Amount": "Valor líquido desembolsado",
       "Disbursed Amount Percentage Down Payment": "Porcentagem do valor desembolsado no pagamento inicial",
       "Disbursed On": "Desembolsado em",
       "Disbursed On Date": "Desembolsado na data",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -1513,6 +1513,7 @@
       "Disabled": "Imezimwa",
       "Disallow Expected Disbursements": "Usiruhusu Ulipaji Unaotarajiwa",
       "Disburse Amount": "Pesa Pesa",
+      "Net Disbursed Amount": "Kiasi Kilichotolewa",
       "Disbursed Amount Percentage Down Payment": "Kiasi Kilichotolewa Asilimia ya Malipo ya Chini",
       "Disbursed On": "Imetolewa",
       "Disbursed On Date": "Imetolewa Tarehe",


### PR DESCRIPTION
## Description

I Added a new row to the "Loan Details" section titled "Net Disbursed Amount", with the aim to provide transparency and clarity to reflect the actual funds disbursed to the client.

## Related issues and discussion

#{Issue Number}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
