### PR TITLE
fix(LMS-110): show active repayments when manually_adjusted_or_reversed is set

### DIFF
--- a/src/app/loans/loans-view/transactions-tab/transactions-tab.component.spec.ts
+++ b/src/app/loans/loans-view/transactions-tab/transactions-tab.component.spec.ts
@@ -1,6 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { UntypedFormControl } from '@angular/forms';
 
 import { TransactionsTabComponent } from './transactions-tab.component';
+import { LoanTransaction } from 'app/products/loan-products/models/loan-account.model';
 
 describe('TransactionsTabComponent', () => {
   let component: TransactionsTabComponent;
@@ -20,5 +22,21 @@ describe('TransactionsTabComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('treats manuallyReversed as active when backend reversed flag is false', () => {
+    const txn = { reversed: false, manuallyReversed: true } as LoanTransaction;
+    expect((component as any).isTransactionReversed(txn)).toBeFalse();
+  });
+
+  it('hides only backend-reversed rows when Show Reversed is off', () => {
+    component.transactionsData = [
+      { id: 1, reversed: false, manuallyReversed: true, type: { accrual: false } } as LoanTransaction,
+      { id: 2, reversed: true, manuallyReversed: false, type: { accrual: false } } as LoanTransaction
+    ];
+    component.hideAccrualsParam = new UntypedFormControl(true);
+    component.showReversedParam = new UntypedFormControl(false);
+    component.filterTransactions(true, true);
+    expect(component.dataSource.data.map((t) => t.id)).toEqual([1]);
   });
 });

--- a/src/app/loans/loans-view/transactions-tab/transactions-tab.component.ts
+++ b/src/app/loans/loans-view/transactions-tab/transactions-tab.component.ts
@@ -157,7 +157,6 @@ export class TransactionsTabComponent implements OnInit {
 
     if (hideAccrual || hideReversed) {
       transactions = this.transactionsData.filter((t: LoanTransaction) => {
-        // Treat both manually reversed and backend-reversed transactions as "reversed"
         const isReversed = this.isTransactionReversed(t);
         return !(hideReversed && isReversed) && !(hideAccrual && t.type.accrual);
       });
@@ -371,13 +370,11 @@ export class TransactionsTabComponent implements OnInit {
   }
 
   /**
-   * Returns true if a transaction is reversed.
-   * We consider both:
-   * - `manuallyReversed` (explicit undo from UI)
-   * - `reversed` flag coming directly from the backend
+   * Returns true when the backend has reversed this transaction.
+   * `manuallyReversed` / `manually_adjusted_or_reversed` marks a reprocess guard on active repayments.
    */
   private isTransactionReversed(transaction: LoanTransaction): boolean {
-    return !!transaction.manuallyReversed || !!transaction.reversed;
+    return !!transaction.reversed;
   }
 
   /**


### PR DESCRIPTION
Loan transactions tab now treats only backend-reversed rows as reversed for Show Reversed filtering, so LPI reprocess guard flags do not hide live payments.

## Description

Describe the changes made and why they were made instead of how they were made. List any dependencies that are required for this change.

## Related issues and discussion

#{Issue Number}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
